### PR TITLE
Adds roles option in database-initialization

### DIFF
--- a/en/installation-guide/database-initialization.rst
+++ b/en/installation-guide/database-initialization.rst
@@ -130,3 +130,4 @@ For instance, run ``./scripts/db_setup.sh -s 2056`` for the **2056** SRID.
 If you already have a data model and you want to force the regeneration
 of the model you can also use the ``-f`` option: ``./scripts/db_setup.sh -f``.
 
+You can use the ``-r`` option to add roles (``qgep_viewer``, ``qgep_user``, ``qgep_manager``, ``qgep_sysadmin``).


### PR DESCRIPTION
Adds a message explaining the ``-r`` option to add roles when initializing the database