### PR TITLE
Restored Transifex commands to Makefile.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,7 @@ jobs:
           curl -OL https://github.com/transifex/cli/releases/download/v1.3.1/tx-linux-amd64.tar.gz
           tar -xvzf tx-linux-amd64.tar.gz
           make gettext
-          ./tx push
-          ./tx pull
-          ./tx status
+          make transifex_pull
 
       - name: build
         run: |

--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,12 @@ init: en/*
 transifex_sync: gettext
 	@set -e;\
 	./scripts/create_transifex_resources.sh; \
-	tx push -s;
+	./tx push -s;
 	@echo "Transifex resources synchronized"
 
 transifex_pull:
 	@set -e;\
-	  tx pull -a;
+	  ./tx pull -a;
 	@echo "Transifex translations pulled"
 
 compile_messages: init


### PR DESCRIPTION
This PR tries to respect more faithfully the previously used approach with `cmake`, running the Transifex commands from `Makefile`.